### PR TITLE
Allow VCS_TYPE to be overriden #7

### DIFF
--- a/src/circle_api.sh
+++ b/src/circle_api.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
-VCS_TYPE="github"
-if [[ *"bitbucket"* = repo_url ]]; then
-	VCS_TYPE = "bitbucket"
+# Default to github, but allow this to be overriden.
+if [ -z $VCS_TYPE ]; then
+	VCS_TYPE="github"
 fi
 
 load_oldest_running_build_num(){


### PR DESCRIPTION
This solves the isse described here:

https://github.com/eddiewebb/circleci-queue/issues/7

You can now do

`VCS_TYPE=bitbucket queueBuildUntilFrontOfLine 5`